### PR TITLE
use the Cairo graphics device (closes #18)

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -4,6 +4,9 @@ library(shinycssloaders) #for loading indicator
 library(tidyverse)
 library(ggsankey)
 
+# Options to make the plot look less aliased on rsconnect
+library(Cairo)
+options(shiny.usecairo = TRUE)
 
 # RStudio Connect runs relative to app/
 articles  <- read_csv("articles_clean.csv")

--- a/renv.lock
+++ b/renv.lock
@@ -9,6 +9,14 @@
     ]
   },
   "Packages": {
+    "Cairo": {
+      "Package": "Cairo",
+      "Version": "1.6-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "60aada7beac23aa3e9b219485d6b2da8",
+      "Requirements": []
+    },
     "DBI": {
       "Package": "DBI",
       "Version": "1.1.3",
@@ -1240,12 +1248,11 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.7",
+      "Version": "3.1.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "08415af406e3dd75049afef9552e7355",
+      "Hash": "56b6934ef0f8c68225949a8672fe1a8f",
       "Requirements": [
-        "ellipsis",
         "fansi",
         "lifecycle",
         "magrittr",


### PR DESCRIPTION
Closes issue #18 by explicitly setting graphics device.  Already tested as separate rsconnect app and it looks much better.