### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/deploy-to-connect.yaml
+++ b/.github/workflows/deploy-to-connect.yaml
@@ -20,12 +20,12 @@ jobs:
       RSCONNECT_APIKEY: ${{ secrets.RSCONNECT_APIKEY }}
       RENV_PATHS_ROOT: ~/.local/share/renv
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@master
 
       - name: Cache packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ env.RENV_PATHS_ROOT }}
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}

--- a/.github/workflows/deploy-to-connect.yaml
+++ b/.github/workflows/deploy-to-connect.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
 
       - name: Cache packages
         uses: actions/cache@v3

--- a/renv.lock
+++ b/renv.lock
@@ -842,10 +842,10 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.0.2",
+      "Version": "2.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6d3bef2e305f55c705c674653c7d7d3d",
+      "Hash": "e86c5ffeb8474a9e03d75f5d2919683e",
       "Requirements": [
         "askpass"
       ]


### PR DESCRIPTION
Some of the steps in the GitHub action to deploy the app are being deprecated soon:
![Screenshot 2022-12-05 at 9 29 00 AM](https://user-images.githubusercontent.com/25404783/205662591-e9a5486f-42f3-4513-86b3-636031ac2cb2.png)

This PR just updates them so this warning won't show up (hopefully) for a while.