### PR TITLE
update github action to use R 4.2

### DIFF
--- a/.github/workflows/deploy-to-connect.yaml
+++ b/.github/workflows/deploy-to-connect.yaml
@@ -25,28 +25,16 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: 4.2.2 #freeze R version
 
-      - name: Cache packages
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-renv-
-      
-      - name: Restore packages
-        shell: Rscript {0}
-        run: |
-          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-          renv::restore()
-      
+      - uses: r-lib/actions/setup-renv@v2
+
       - name: Install rsconnect
         shell: Rscript {0}
         run: |
           if (!requireNamespace("packrat", quietly = TRUE)) install.packages("packrat")
           if (!requireNamespace("rsconnect", quietly = TRUE)) install.packages("rsconnect")
           if (!requireNamespace("Cairo", quietly = TRUE)) install.packages("Cairo")
-          options(shiny.usecairo = TRUE) #to fix bad aliasing in plots
 
 # For more detailed documentation on the following steps see 
 # https://github.com/rstudio/actions/tree/main/connect-publish
@@ -58,6 +46,8 @@ jobs:
 
       - name: Deploy to RStudio Connect
         uses: rstudio/actions/connect-publish@main
+        env:
+          CONNECT_ENV_SET_SHINY_USECAIRO: true
         with:
           url: https://${{ env.RSCONNECT_APIKEY }}@${{ env.RSCONNECT_URL }}
           access-type: all


### PR DESCRIPTION
Updates github action for deploying app to freeze the R version at 4.2.2.  Also simplifies things by using new-ish setup-renv action and correctly sets the option to use Cairo for rendering on Posit Connect.