### PR TITLE
Add manual deploy button

### DIFF
--- a/.github/workflows/deploy-to-connect.yaml
+++ b/.github/workflows/deploy-to-connect.yaml
@@ -3,6 +3,7 @@
 # 2) https://rstudio.github.io/renv/articles/ci.html
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Adds an additional trigger for the GitHub action that publishes this app to Posit Connect that lets you just click a button in the Actions tab to run it.  After a recent upgrade of U of A's Posit Connect server, the deployed app isn't runnning.  It should be fine after being re-published though.